### PR TITLE
Slug on insta_users based on username

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,4 +80,4 @@ gem 'faraday', '~> 2.6'
 
 gem 'friendly_id', '~> 5.4'
 
-gem "data_migrate", "~> 8.1"
+gem 'data_migrate', '~> 8.1'

--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,5 @@ end
 gem 'faraday', '~> 2.6'
 
 gem 'friendly_id', '~> 5.4'
+
+gem "data_migrate", "~> 8.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,9 @@ GEM
     childprocess (4.1.0)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
+    data_migrate (8.1.1)
+      activerecord (>= 5.0)
+      railties (>= 5.0)
     debug (1.6.2)
       irb (>= 1.3.6)
       reline (>= 0.3.1)
@@ -262,6 +265,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
+  data_migrate (~> 8.1)
   debug
   erb_lint
   faraday (~> 2.6)

--- a/app/models/insta_user.rb
+++ b/app/models/insta_user.rb
@@ -6,7 +6,7 @@ class InstaUser < ApplicationRecord
   # enum account_types: { BUSINESS, MEDIA_CREATOR, PERSONAL }
 
   extend FriendlyId
-  friendly_id :username, use: %i[finders]
+  friendly_id :username, use: %i[slugged finders]
 
   def display_username
     ['@', username].join

--- a/db/data/20221022174636_update_insta_user_slugs.rb
+++ b/db/data/20221022174636_update_insta_user_slugs.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UpdateInstaUserSlugs < ActiveRecord::Migration[7.0]
+  def up
+    InstaUser.find_each(&:save)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,0 +1,1 @@
+DataMigrate::Data.define(version: 20221022174636)

--- a/db/migrate/20221022174340_add_slug_to_insta_users.rb
+++ b/db/migrate/20221022174340_add_slug_to_insta_users.rb
@@ -1,0 +1,6 @@
+class AddSlugToInstaUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :insta_users, :slug, :string
+    add_index :insta_users, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,6 +14,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_22_174340) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
   create_table "insta_access_tokens", force: :cascade do |t|
     t.string "access_token"
     t.integer "expires_in"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_21_095033) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_22_174340) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,7 +44,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_21_095033) do
     t.integer "media_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "slug"
     t.index ["remote_id"], name: "index_insta_users_on_remote_id", unique: true
+    t.index ["slug"], name: "index_insta_users_on_slug", unique: true
     t.index ["username"], name: "index_insta_users_on_username", unique: true
   end
 


### PR DESCRIPTION
instagram allows usernames that are not url-friendly. 

`za.yuliia` in the url was giving me errors :(

that's why we will need a slug column.

an friendly url that works out of the box would be `'za.yuliia'.parametrize`.

when adding gem data_migrate we need to update the run command:

```diff
-rails db:migrate
+rails db:migrate:with_data
```