### PR TITLE
Button to trigger posts refresh

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   def current_user
     @current_user ||= InstaUser.find(session[:insta_user_id]) if session[:insta_user_id]
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
   helper_method :current_user
 end

--- a/app/controllers/insta_posts_controller.rb
+++ b/app/controllers/insta_posts_controller.rb
@@ -1,17 +1,19 @@
 class InstaPostsController < ApplicationController
-  before_action :set_user, only: %i[index show]
+  before_action :set_user
 
   def index
-    # should not be called here. should be some button to "import" that would trigger a job.
-    InstaMediaService.new(@insta_user).call unless Rails.env.development? # faster when not needed for now.
-    # InstaMediaService.new(@insta_user).call
-
     posts = @insta_user.insta_posts.order(timestamp: :desc)
     @posts = if params[:caption].present?
                posts.where('caption ilike ?', "%#{params[:caption]}%")
              else
                posts
              end
+  end
+
+  def refresh
+    # TODO: should trigger a job
+    InstaMediaService.new(@insta_user).call
+    redirect_to insta_user_path(@insta_user)
   end
 
   def show

--- a/app/views/insta_posts/_insta_post.html.erb
+++ b/app/views/insta_posts/_insta_post.html.erb
@@ -1,7 +1,5 @@
 <article class='bg-slate-50 border border-slate-300 rounded-md p-4 lg:w-1/3 md:w-2/3 sm:w-full hover:bg-slate-100'>
   <div>
-  <%#= link_to insta_user_post_path(post.insta_user, post) do %>
-  <%# end %>
     <% if post.image? || post.carousel_album? %>
       <%= image_tag post.media_url %>
     <% elsif post.video? %>
@@ -16,7 +14,14 @@
       🕚 <%= post.timestamp.to_fs(:long) %>
     </p>
     <p>
-      🔗 <%= link_to post.remote_id, post.permalink, target: '_blank', rel: 'noopener' %>
+    <%= link_to insta_user_post_path(post.insta_user, post) do %>
+      🔍 view
+    <% end %>
+    </p>
+    <p>
+    <%= link_to post.permalink, target: '_blank', rel: 'noopener' do %>
+      🔗 view on Instagram
+    <% end %>
     </p>
   </div>
 </article>

--- a/app/views/insta_posts/index.html.erb
+++ b/app/views/insta_posts/index.html.erb
@@ -1,30 +1,30 @@
 <div class='flex flex-col space-y-4 items-center'>
-  <%= @insta_user.display_username %>
-</div>
-
-<%= form_with url: insta_user_posts_path(@insta_user),
-              method: :get,
-              class: 'flex flex-col items-center my-4',
-              data: { controller: 'debounce',
-                      debounce_target: 'form',
-                      turbo_frame: 'results' } do |form| %>
-  <%= form.text_field :caption,
-                      placeholder: 'Caption',
-                      value: params[:caption],
-                      autocomplete: 'off',
-                      autofocus: true,
-                      class: 'rounded-md border border-slate-300',
-                      data: { action: 'input->debounce#search' } %>
-<% end %>
-
-<%= turbo_frame_tag 'results', target: '_top', data: { turbo_action: 'advance' } do %>
-  <%#= request.url %>
-  <%#= link_to 'Clear search', request.path if request.query_parameters.any? %>
-
-  <div class='flex flex-col space-y-4 items-center'>
-    <% @posts.each do |post| %>
-      <%= render partial: 'insta_posts/insta_post', locals: { post: } %>
-    <% end %>
+  <div>
+    <%= @insta_user.display_username %>
   </div>
-<% end %>
 
+  <%= form_with url: insta_user_posts_path(@insta_user),
+                method: :get,
+                data: { controller: 'debounce',
+                        debounce_target: 'form',
+                        turbo_frame: 'results' } do |form| %>
+    <%= form.text_field :caption,
+                        placeholder: 'Caption',
+                        value: params[:caption],
+                        autocomplete: 'off',
+                        autofocus: true,
+                        class: 'rounded-md border border-slate-300',
+                        data: { action: 'input->debounce#search' } %>
+  <% end %>
+
+  <%= turbo_frame_tag 'results', target: '_top', data: { turbo_action: 'advance' } do %>
+    <%#= request.url %>
+    <%#= link_to 'Clear search', request.path if request.query_parameters.any? %>
+
+    <div class='flex flex-col space-y-4 items-center'>
+      <% @posts.each do |post| %>
+        <%= render partial: 'insta_posts/insta_post', locals: { post: } %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/insta_posts/show.html.erb
+++ b/app/views/insta_posts/show.html.erb
@@ -1,3 +1,7 @@
 <div class='flex flex-col space-y-4 items-center'>
+  <div>
+    <%= @insta_user.display_username %>
+  </div>
+
   <%= render partial: 'insta_posts/insta_post', locals: { post: @post } %>
 </div>

--- a/app/views/insta_users/show.html.erb
+++ b/app/views/insta_users/show.html.erb
@@ -1,6 +1,15 @@
 <div class='flex flex-col space-y-4 items-center'>
-  <%= render partial: 'insta_users/insta_user', locals: { insta_user: @insta_user } %>
-  <%= link_to insta_user_posts_path(@insta_user), class: 'bg-slate-50 border border-slate-300 rounded-md p-4 lg:w-1/3 md:w-2/3 sm:w-full hover:bg-slate-100' do %>
-    🖼 Posts: <%= @insta_user.media_count %>
+  <div>
+    <%= @insta_user.display_username %>
+  </div>
+
+  <%= button_to refresh_insta_user_posts_path(@insta_user), class: 'bg-slate-50 border border-slate-300 rounded-md p-4 hover:bg-slate-100' do %>
+    <span>🔑 Refresh posts</span>
+  <% end %>
+
+  <% if @insta_user.insta_posts.any? %>
+    <%= link_to insta_user_posts_path(@insta_user), class: 'bg-slate-50 border border-slate-300 rounded-md p-4 hover:bg-slate-100' do %>
+      🖼 Posts: <%= @insta_user.media_count %>
+    <% end %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,6 @@ Rails.application.routes.draw do
   get 'u/:id', to: 'insta_users#show', as: :insta_user
   get 'u', to: 'insta_users#index', as: :insta_users
   get 'u/:id/p', to: 'insta_posts#index', as: :insta_user_posts
+  post 'u/:id/p/refresh', to: 'insta_posts#refresh', as: :refresh_insta_user_posts
   get 'u/:id/p/:post_id', to: 'insta_posts#show', as: :insta_user_post
 end

--- a/test/integration/insta_posts_test.rb
+++ b/test/integration/insta_posts_test.rb
@@ -2,19 +2,33 @@ require 'test_helper'
 
 class InstaPostsTest < ActionDispatch::IntegrationTest
   def setup
-    @user = InstaUser.create(username: 'yaro_the_slav', remote_id: 123)
+    @user = InstaUser.create(username: 'yaro_the_slav', remote_id: SecureRandom.random_number(9999))
     @user.insta_access_tokens.create
   end
 
   test 'index' do
-    skip # will stub faraday requests later
+    InstaPost.create(insta_user: @user, remote_id: SecureRandom.random_number(9999), timestamp: Time.zone.now,
+                     caption: 'Post by this user')
+    user2 = InstaUser.create(username: 'za.yuliia', remote_id: SecureRandom.random_number(9999))
+    InstaPost.create(insta_user: user2, remote_id: SecureRandom.random_number(9999), timestamp: Time.zone.now,
+                     caption: 'Post by other user')
     get insta_user_posts_url(@user)
+
     assert_response :success
+
+    assert_match 'Post by this user', response.body
+    assert_no_match 'Post by other user', response.body
   end
 
   test 'show' do
-    @post = InstaPost.create(insta_user: @user, remote_id: 123, timestamp: Time.zone.now)
+    @post = InstaPost.create(insta_user: @user, remote_id: SecureRandom.random_number(9999), timestamp: Time.zone.now)
     get insta_user_post_url(@user, @post)
+    assert_response :success
+  end
+
+  test 'refresh' do
+    skip # will stub faraday requests later
+    post refresh_insta_user_posts_path(@user)
     assert_response :success
   end
 end


### PR DESCRIPTION
before posts were refreshed via an API call whenever you go to `/posts`. 
that does not make any sence for:
* $ 
* speed 
* will soon hit the Insta API call limit

=> separate button to refresh posts.
There will also be a (daily? hourly?) job to do so.

Also, save from `current_user` error if can not find user