### PR TITLE
Counter cache users on posts, improve copy

### DIFF
--- a/app/controllers/insta_posts_controller.rb
+++ b/app/controllers/insta_posts_controller.rb
@@ -10,10 +10,10 @@ class InstaPostsController < ApplicationController
              end
   end
 
-  def refresh
-    # TODO: should trigger a job
+  def import
+    # TODO: should (also) trigger by a job
     InstaMediaService.new(@insta_user).call
-    redirect_to insta_user_path(@insta_user)
+    redirect_to insta_user_posts_path(@insta_user), notice: t('.success')
   end
 
   def show

--- a/app/models/insta_post.rb
+++ b/app/models/insta_post.rb
@@ -1,5 +1,5 @@
 class InstaPost < ApplicationRecord
-  belongs_to :insta_user
+  belongs_to :insta_user, counter_cache: true
   validates :remote_id, presence: true, uniqueness: true
   enum media_type: { video: 'video', image: 'image', carousel_album: 'carousel_album' }
 

--- a/app/views/insta_posts/index.html.erb
+++ b/app/views/insta_posts/index.html.erb
@@ -1,6 +1,6 @@
 <div class='flex flex-col space-y-4 items-center'>
   <div>
-    <%= @insta_user.at_username %>
+    <%= link_to_unless_current @insta_user.at_username, insta_user_path(@insta_user) %>
   </div>
 
   <%= form_with url: insta_user_posts_path(@insta_user),

--- a/app/views/insta_posts/show.html.erb
+++ b/app/views/insta_posts/show.html.erb
@@ -1,6 +1,6 @@
 <div class='flex flex-col space-y-4 items-center'>
   <div>
-    <%= @insta_user.at_username %>
+    <%= link_to_unless_current @insta_user.at_username, insta_user_path(@insta_user) %>
   </div>
 
   <%= render partial: 'insta_posts/insta_post', locals: { post: @post } %>

--- a/app/views/insta_users/show.html.erb
+++ b/app/views/insta_users/show.html.erb
@@ -1,6 +1,6 @@
 <div class='flex flex-col space-y-4 items-center'>
   <div>
-    <%= @insta_user.at_username %>
+    <%= link_to_unless_current @insta_user.at_username, insta_user_path(@insta_user) %>
   </div>
 
   <% if @insta_user.insta_posts.none? %>
@@ -14,15 +14,27 @@
         Click 'Import' to continue!
       </p>
     </div>
-  <% end %>
-
-  <%= button_to import_insta_user_posts_path(@insta_user), class: 'bg-slate-50 border border-slate-300 rounded-md p-4 hover:bg-slate-100' do %>
-    <span>🔑 Import posts</span>
-  <% end %>
-
-  <% if @insta_user.insta_posts.any? %>
+  <% else %>
+    <div class='text-center'>
+      <p>
+        Don't see your latest posts in the feed?
+      </p>
+      <p>
+        Click <strong>Import</strong>!
+      </p>
+        Your posts are refreshed only when you click <strong>Import</strong>.
+      </p>
+      <p>
+        To automatically refresh posts, check our
+        <%= link_to 'Pricing', pricing_path %>.
+      </p>
+    </div>
     <%= link_to insta_user_posts_path(@insta_user), class: 'bg-slate-50 border border-slate-300 rounded-md p-4 hover:bg-slate-100' do %>
       🖼 Posts: <%= @insta_user.insta_posts_count %>
     <% end %>
+  <% end %>
+
+  <%= button_to import_insta_user_posts_path(@insta_user), class: 'bg-slate-50 border border-slate-300 rounded-md p-4 hover:bg-slate-100' do %>
+    <span>▶️ Import posts</span>
   <% end %>
 </div>

--- a/app/views/insta_users/show.html.erb
+++ b/app/views/insta_users/show.html.erb
@@ -3,13 +3,26 @@
     <%= @insta_user.at_username %>
   </div>
 
-  <%= button_to refresh_insta_user_posts_path(@insta_user), class: 'bg-slate-50 border border-slate-300 rounded-md p-4 hover:bg-slate-100' do %>
-    <span>🔑 Refresh posts</span>
+  <% if @insta_user.insta_posts.none? %>
+    <div class='text-center'>
+      <p>
+        We have detected
+        <strong><%= @insta_user.media_count %></strong>
+        posts on your instagram feed.
+      </p>
+      <p>
+        Click 'Import' to continue!
+      </p>
+    </div>
+  <% end %>
+
+  <%= button_to import_insta_user_posts_path(@insta_user), class: 'bg-slate-50 border border-slate-300 rounded-md p-4 hover:bg-slate-100' do %>
+    <span>🔑 Import posts</span>
   <% end %>
 
   <% if @insta_user.insta_posts.any? %>
     <%= link_to insta_user_posts_path(@insta_user), class: 'bg-slate-50 border border-slate-300 rounded-md p-4 hover:bg-slate-100' do %>
-      🖼 Posts: <%= @insta_user.media_count %>
+      🖼 Posts: <%= @insta_user.insta_posts_count %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,8 +17,8 @@
 
   <body class="flex flex-col min-h-screen bg-slate-100">
     <header>
-      <%= render 'shared/flash' %>
       <%= render 'shared/nav' %>
+      <%= render 'shared/flash' %>
     </header>
     <main class='p-4 break-normal'>
       <%= yield %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,3 +34,6 @@ en:
   sessions:
     logout:
       success: You have logged out
+  insta_posts:
+    import:
+      success: Posts have been imported!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,6 @@ Rails.application.routes.draw do
   get 'u/:id', to: 'insta_users#show', as: :insta_user
   get 'u', to: 'insta_users#index', as: :insta_users
   get 'u/:id/p', to: 'insta_posts#index', as: :insta_user_posts
-  post 'u/:id/p/refresh', to: 'insta_posts#refresh', as: :refresh_insta_user_posts
+  post 'u/:id/p/import', to: 'insta_posts#import', as: :import_insta_user_posts
   get 'u/:id/p/:post_id', to: 'insta_posts#show', as: :insta_user_post
 end

--- a/db/data/20221022215805_calculate_counter_cache_posts_for_user.rb
+++ b/db/data/20221022215805_calculate_counter_cache_posts_for_user.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CalculateCounterCachePostsForUser < ActiveRecord::Migration[7.0]
+  def up
+    InstaUser.find_each { |u| InstaUser.reset_counters(u.id, :insta_posts) }
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20221022174636)
+DataMigrate::Data.define(version: 20221022215805)

--- a/db/migrate/20221022215628_add_insta_posts_count_to_insta_users.rb
+++ b/db/migrate/20221022215628_add_insta_posts_count_to_insta_users.rb
@@ -1,0 +1,5 @@
+class AddInstaPostsCountToInstaUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :insta_users, :insta_posts_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_22_174340) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_22_215628) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_22_174340) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "slug"
+    t.integer "insta_posts_count", default: 0, null: false
     t.index ["remote_id"], name: "index_insta_users_on_remote_id", unique: true
     t.index ["slug"], name: "index_insta_users_on_slug", unique: true
     t.index ["username"], name: "index_insta_users_on_username", unique: true

--- a/test/integration/insta_posts_test.rb
+++ b/test/integration/insta_posts_test.rb
@@ -26,9 +26,9 @@ class InstaPostsTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'refresh' do
+  test 'import' do
     skip # will stub faraday requests later
-    post refresh_insta_user_posts_path(@user)
+    post import_insta_user_posts_path(@user)
     assert_response :success
   end
 end


### PR DESCRIPTION
media_count (that is takend from the insta API) is not always accurate with the count of posts in the app.
media_count is also not accurate with posts count displayed in instagram profile.

add posts_count to user to have real posts count.

improve copy around importing posts:
no posts:
<img width="546" alt="Screenshot 2022-10-23 at 00 17 40" src="https://user-images.githubusercontent.com/13472945/197364344-d9d0347b-5fe6-4991-ac91-61b8c9f4a4d7.png">

already has posts:
<img width="548" alt="Screenshot 2022-10-23 at 00 17 29" src="https://user-images.githubusercontent.com/13472945/197364355-0eeeedad-bf89-4510-ac08-90f24ce9b28d.png">
