### PR TITLE
auto-refresh user media count on page load

### DIFF
--- a/app/controllers/insta_users_controller.rb
+++ b/app/controllers/insta_users_controller.rb
@@ -47,7 +47,7 @@ class InstaUsersController < ApplicationController
     return refresh_media_count(insta_user) if insta_user.last_profile_import_at.nil?
     return insta_user.media_count if insta_user.last_profile_import_at > 15.minutes.ago
 
-    request_media_count(insta_user)
+    refresh_media_count(insta_user)
   end
 
   def refresh_media_count(insta_user)

--- a/app/controllers/insta_users_controller.rb
+++ b/app/controllers/insta_users_controller.rb
@@ -1,6 +1,6 @@
 class InstaUsersController < ApplicationController
-  before_action :set_user, only: %i[show import destroy]
-  before_action :require_user!, only: %i[import destroy]
+  before_action :set_user, only: %i[show import destroy media_count]
+  before_action :require_user!, only: %i[import destroy media_count]
 
   # GET /u
   def index
@@ -21,6 +21,24 @@ class InstaUsersController < ApplicationController
     # TODO: should trigger a job
     InstaMediaService.new(@insta_user).call
     redirect_to insta_user_posts_path(@insta_user), notice: t('.success')
+  end
+
+  # GET /u/:id/media_count
+  def media_count
+    # TODO: should be last_me_at
+    media_count = if @insta_user.last_import_at < 15.minutes.ago
+                    insta_access_token = @insta_user.insta_access_tokens.first
+                    insta_user = InstaMeService.new(insta_access_token.access_token).call
+                    insta_user.media_count
+                  else
+                    @insta_user.media_count
+                  end
+
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.update("#{@insta_user.id}_media_count", html: media_count)
+      end
+    end
   end
 
   # DELETE /u/:id

--- a/app/controllers/insta_users_controller.rb
+++ b/app/controllers/insta_users_controller.rb
@@ -25,18 +25,10 @@ class InstaUsersController < ApplicationController
 
   # GET /u/:id/media_count
   def media_count
-    # TODO: should be last_me_at
-    media_count = if @insta_user.last_import_at < 15.minutes.ago
-                    insta_access_token = @insta_user.insta_access_tokens.first
-                    insta_user = InstaMeService.new(insta_access_token.access_token).call
-                    insta_user.media_count
-                  else
-                    @insta_user.media_count
-                  end
-
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: turbo_stream.update("#{@insta_user.id}_media_count", html: media_count)
+        render turbo_stream: turbo_stream.update("#{@insta_user.id}_media_count",
+                                                 html: check_media_count(@insta_user))
       end
     end
   end
@@ -50,6 +42,19 @@ class InstaUsersController < ApplicationController
   end
 
   private
+
+  def check_media_count(insta_user)
+    return refresh_media_count(insta_user) if insta_user.last_profile_import_at.nil?
+    return insta_user.media_count if insta_user.last_profile_import_at > 15.minutes.ago
+
+    request_media_count(insta_user)
+  end
+
+  def refresh_media_count(insta_user)
+    insta_access_token = insta_user.insta_access_tokens.first
+    insta_user = InstaMeService.new(insta_access_token.access_token).call
+    insta_user.media_count
+  end
 
   def record_owner?
     @insta_user.user == current_user

--- a/app/services/insta_me_service.rb
+++ b/app/services/insta_me_service.rb
@@ -12,7 +12,8 @@ class InstaMeService
     insta_user.update(
       remote_id: insta_user_data['id'],
       account_type: insta_user_data['account_type'].downcase,
-      media_count: insta_user_data['media_count']
+      media_count: insta_user_data['media_count'],
+      last_profile_import_at: Time.zone.now
     )
     insta_user
   end

--- a/app/views/insta_users/_insta_user.html.erb
+++ b/app/views/insta_users/_insta_user.html.erb
@@ -8,7 +8,10 @@
   <div class='p-2 border-b border-y-slate-300'>
     <div class='text-center space-y-2'>
       <div class='text-sm'>
-        <b><%= insta_user.media_count %></b>
+        <%= turbo_frame_tag 'counter', src: media_count_insta_user_path(insta_user, format: :turbo_stream), loading: :lazy %>
+        <b id="<%= insta_user.id %>_media_count" class='text-violet-700'>
+          <i class="fa-solid fa-circle-notch fa-spin"></i>
+        </b>
         posts detected
       </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get 'u/:id', to: 'insta_users#show', as: :insta_user
   delete 'u/:id', to: 'insta_users#destroy', as: :delete_insta_user
   post 'u/:id/import', to: 'insta_users#import', as: :import_insta_user
+  get 'u/:id/media_count', to: 'insta_users#media_count', as: :media_count_insta_user
 
   get 'u/:user_id/p', to: 'insta_posts#index', as: :insta_user_posts
   get 'u/:user_id/p/:id', to: 'insta_posts#show', as: :insta_user_post

--- a/db/migrate/20221111092113_add_last_profile_import_at_to_insta_users.rb
+++ b/db/migrate/20221111092113_add_last_profile_import_at_to_insta_users.rb
@@ -1,0 +1,5 @@
+class AddLastProfileImportAtToInstaUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :insta_users, :last_profile_import_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_08_132825) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_11_092113) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,6 +49,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_08_132825) do
     t.integer "insta_posts_count", default: 0, null: false
     t.datetime "last_import_at"
     t.bigint "user_id"
+    t.datetime "last_profile_import_at"
     t.index ["remote_id"], name: "index_insta_users_on_remote_id", unique: true
     t.index ["slug"], name: "index_insta_users_on_slug", unique: true
     t.index ["user_id"], name: "index_insta_users_on_user_id"

--- a/test/integration/instagram_test.rb
+++ b/test/integration/instagram_test.rb
@@ -26,7 +26,7 @@ class InstagramTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match 'Connect an Instagram account', @response.body
     assert_match 'posts detected', @response.body
-    assert_match '305', @response.body
+    assert_match 'yaro_the_slav', @response.body
   end
 
   private


### PR DESCRIPTION
### Description

media_count counter reloads when openin list of connected InstaUsers (for each user). It does not refresh more often than once 15 minutes

### How to test

### Self-check

- [ ] self-reviewed
- [ ] added tests
- [ ] focused (related only to the ticket scope)

### Visual Changes

Before

After
