### PR TITLE
use www subdomain for default mailer in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,7 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
-  config.action_mailer.default_url_options = { host: "insta2blog.com", protocol: "https" }
+  config.action_mailer.default_url_options = { host: "www.insta2blog.com", protocol: "https" }
   config.action_mailer.perform_deliveries = true
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {


### PR DESCRIPTION
### Description

this way we will not have logged-in users in non-www;

### How to test

### Self-check

- [ ] self-reviewed
- [ ] added tests
- [ ] focused (related only to the ticket scope)

### Visual Changes

Before

After
