### PR TITLE
hadle insta api errors

### DIFF
--- a/app/controllers/insta_users_controller.rb
+++ b/app/controllers/insta_users_controller.rb
@@ -57,8 +57,11 @@ class InstaUsersController < ApplicationController
 
   def refresh_media_count(insta_user)
     insta_access_token = insta_user.insta_access_tokens.first
-    insta_user = InstaMeService.new(insta_access_token.access_token).call
-    insta_user.media_count
+    fresh_insta_user = InstaMeService.new(insta_access_token.access_token).call
+    # TODO: update insta_user status to requires_authentication
+    return 0 unless fresh_insta_user
+
+    fresh_insta_user.media_count
   end
 
   def record_owner?

--- a/app/services/insta_me_service.rb
+++ b/app/services/insta_me_service.rb
@@ -8,6 +8,8 @@ class InstaMeService
 
   def call
     insta_user_data = ask_user_profile
+    return if insta_user_data.blank?
+
     insta_user = InstaUser.find_or_initialize_by(username: insta_user_data['username'])
     insta_user.update(
       remote_id: insta_user_data['id'],
@@ -25,6 +27,8 @@ class InstaMeService
       req.headers = headers,
                     req.params = user_params(long_lived_access_token)
     end
+    return unless response.success?
+
     JSON.parse(response.body)
     # {"id"=>"5973192396032263", "username"=>"yaro_the_slav", "account_type"=>"PERSONAL", "media_count"=>305}
   end


### PR DESCRIPTION
### Description

in case if the user changes his password or deauthorizez the app, we should reflect the GetMedia failure:
- catch and handle errors
- add `connection_status` attribute to `insta_user`
- change insta_users `connection_status` to "requires authentication"

### How to test

### Self-check

- [ ] self-reviewed
- [ ] added tests
- [ ] focused (related only to the ticket scope)

### Visual Changes

Before

After
